### PR TITLE
Fix download URL for Software Carpentry Installer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,8 @@ lc_site: "https://librarycarpentry.github.io/"
 swc_github: "https://github.com/swcarpentry"
 swc_pages: "https://swcarpentry.github.io"
 swc_site: "https://software-carpentry.org"
+swc_installer: "https://files.software-carpentry.org/SWCarpentryInstaller.exe"
+
 template_repo: "https://github.com/carpentries/styles"
 training_site: "https://carpentries.github.io/instructor-training"
 workshop_repo: "https://github.com/carpentries/workshop-template"


### PR DESCRIPTION
Sets swc_installer based on value seen for other software carpentry repos:
(https://github.com/BIDS/2015-12-14-berkeley/blob/c4334ddd1f7a4d97c2055cab39a40823dcf9ee9e/_config.yml)
